### PR TITLE
fix: move CV parsing to build-time to avoid serverless runtime errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ next-env.d.ts
 coverage/
 .nyc_output
 
+# Build artifacts
+src/data/cv.txt
+
 # Misc
 *.pem
 *.log

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  serverExternalPackages: ['pdf-parse', '@napi-rs/canvas'],
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/extract-cv.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/scripts/extract-cv.mjs
+++ b/scripts/extract-cv.mjs
@@ -1,0 +1,30 @@
+/**
+ * Build-time script: extracts text from the CV PDF and writes it to
+ * a plain text file that the server can read at runtime without
+ * needing pdf-parse (which requires browser APIs unavailable on Lambda).
+ *
+ * Runs automatically before `next build` via the package.json prebuild hook.
+ */
+
+import { readFile, writeFile, mkdir } from 'fs/promises'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { PDFParse } from 'pdf-parse'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = join(__dirname, '..')
+
+const CV_PDF = join(root, 'public', 'david-cv.pdf')
+const CV_TXT = join(root, 'src', 'data', 'cv.txt')
+
+try {
+  const buffer = await readFile(CV_PDF)
+  const pdf = new PDFParse({ data: new Uint8Array(buffer) })
+  const result = await pdf.getText()
+  await mkdir(dirname(CV_TXT), { recursive: true })
+  await writeFile(CV_TXT, result.text.trim(), 'utf-8')
+  console.log(`✓ CV extracted: ${CV_TXT} (${result.text.trim().length} chars)`)
+} catch (err) {
+  console.error('✗ Failed to extract CV:', err.message)
+  await writeFile(CV_TXT, '(CV unavailable)', 'utf-8')
+}

--- a/src/lib/systemPrompt.ts
+++ b/src/lib/systemPrompt.ts
@@ -1,6 +1,5 @@
 import { readFile } from 'fs/promises'
 import { join } from 'path'
-import { PDFParse } from 'pdf-parse'
 import {
   personalInfo,
   experience,
@@ -11,22 +10,20 @@ import {
 } from '@/data/content'
 import { buildPromptFromSections } from './promptTemplate'
 
-/* ─── CV Parser ────────────────────────────────────────────────────── */
+/* ─── CV Reader ────────────────────────────────────────────────────── */
 
 let cachedCvText: string | null = null
 
-async function parseCv(): Promise<string> {
+/** Reads pre-extracted CV text generated at build time by scripts/extract-cv.mjs */
+async function readCv(): Promise<string> {
   if (cachedCvText) return cachedCvText
 
   try {
-    const cvPath = join(process.cwd(), 'public', 'david-cv.pdf')
-    const buffer = await readFile(cvPath)
-    const pdf = new PDFParse({ data: new Uint8Array(buffer) })
-    const result = await pdf.getText()
-    cachedCvText = result.text.trim()
+    const cvPath = join(process.cwd(), 'src', 'data', 'cv.txt')
+    cachedCvText = (await readFile(cvPath, 'utf-8')).trim()
     return cachedCvText
   } catch (err) {
-    console.error('Failed to parse CV PDF:', err)
+    console.error('Failed to read CV text:', err)
     return '(CV unavailable)'
   }
 }
@@ -91,7 +88,7 @@ function formatProjects(): string {
 /* ─── System Prompt Builder ────────────────────────────────────────── */
 
 export async function buildSystemPrompt(): Promise<string> {
-  const cvText = await parseCv()
+  const cvText = await readCv()
 
   const today = new Date()
   const currentDate = today.toLocaleDateString('en-GB', {


### PR DESCRIPTION
## Problem

Chat API crashes on Amplify (Lambda) with `DOMMatrix is not defined` and `Cannot load @napi-rs/canvas`. The `pdf-parse` library
 requires browser APIs that don't exist in Lambda's Node.js runtime — the error occurs at module import time, before any
try/catch can handle it.

## Fix

- Add `scripts/extract-cv.mjs` — prebuild script that extracts PDF text to `src/data/cv.txt`
- Update `systemPrompt.ts` — reads plain text file at runtime instead of importing `pdf-parse`
- Add `prebuild` hook to `package.json` so extraction runs automatically before `next build`
- Remove `serverExternalPackages` from `next.config.ts` (no longer needed)