### PR TITLE
refactor: migrate Tailwind from CDN to npm v4

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,42 @@
-/* Tailwind is loaded via CDN in layout.tsx */
+@import "tailwindcss";
+
+@theme extend {
+  --color-void:     #060810;
+  --color-surface:  #0b0d17;
+  --color-elevated: #10131f;
+  --color-raised:   #161a2a;
+  --color-accent:   #5eead4;
+  --color-warm:     #d4a853;
+
+  --font-sans:  var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-mono:  var(--font-geist-mono), ui-monospace, monospace;
+  --font-serif: "Playfair Display", Georgia, serif;
+}
+
+/* ─── Base resets (moved from layout.tsx inline <style>) ────────────── */
 
 * {
   scrollbar-width: thin;
   scrollbar-color: rgba(240, 237, 230, 0.08) transparent;
 }
+
+*, ::before, ::after {
+  border-color: rgba(240, 237, 230, 0.12);
+}
+
+html { scroll-behavior: smooth; }
+
+::selection {
+  background: rgba(94, 234, 212, 0.25);
+  color: #f0ede6;
+}
+
+body {
+  background-color: #060810;
+  color: #f0ede6;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+.hide-scroll::-webkit-scrollbar { display: none; }
+.hide-scroll { -ms-overflow-style: none; scrollbar-width: none; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
+import './globals.css'
 
 /* ─── Fonts ─────────────────────────────────────────────────────────── */
 
@@ -64,76 +65,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <script src="https://cdn.tailwindcss.com" />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              tailwind.config = {
-                theme: {
-                  extend: {
-                    colors: {
-                      void: '#060810',
-                      surface: '#0b0d17',
-                      elevated: '#10131f',
-                      raised: '#161a2a',
-                      accent: '#5eead4',
-                      warm: '#d4a853',
-                    },
-                    fontFamily: {
-                      sans: ['var(--font-geist-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-                      mono: ['var(--font-geist-mono)', 'ui-monospace', 'monospace'],
-                      serif: ['Playfair Display', 'Georgia', 'serif'],
-                    },
-                    animation: {
-                      spinSlow: 'spinSlow 12s linear infinite',
-                      spinSlowReverse: 'spinSlowReverse 8s linear infinite',
-                      dataFlow: 'dataFlow 1.2s linear infinite',
-                      fadeInTerminal: 'fadeInTerminal 0s ease-in forwards',
-                    },
-                    keyframes: {
-                      dataFlow: {
-                        '0%': { left: '-20%', opacity: '0' },
-                        '20%': { opacity: '1' },
-                        '80%': { opacity: '1' },
-                        '100%': { left: '100%', opacity: '0' },
-                      },
-                      spinSlow: {
-                        from: { transform: 'rotate(0deg)' },
-                        to: { transform: 'rotate(360deg)' },
-                      },
-                      spinSlowReverse: {
-                        from: { transform: 'rotate(360deg)' },
-                        to: { transform: 'rotate(0deg)' },
-                      },
-                      fadeInTerminal: {
-                        to: { opacity: '1' },
-                      },
-                    },
-                  },
-                },
-              }
-            `,
-          }}
-        />
         <link
           href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap"
           rel="stylesheet"
           crossOrigin="anonymous"
         />
-        <style>{`
-          * { box-sizing: border-box; margin: 0; padding: 0; }
-          html { scroll-behavior: smooth; }
-          ::selection { background: rgba(94, 234, 212, 0.25); color: #f0ede6; }
-          body {
-            background-color: #060810;
-            color: #f0ede6;
-            -webkit-font-smoothing: antialiased;
-            overflow-x: hidden;
-          }
-          .font-serif { font-family: 'Playfair Display', Georgia, serif; }
-          .hide-scroll::-webkit-scrollbar { display: none; }
-          .hide-scroll { -ms-overflow-style: none; scrollbar-width: none; }
-        `}</style>
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} bg-void text-[#f0ede6] antialiased`}>
         {children}

--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -26,7 +26,7 @@ function CopyButton({ text }: { text: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="absolute -bottom-6 right-0 flex items-center gap-1 rounded-md px-1.5 py-0.5 font-mono text-[10px] text-white/0 transition-all group-hover:text-white/30 hover:!bg-white/5 hover:!text-white/60"
+      className="absolute -bottom-6 right-0 flex items-center gap-1 rounded-md px-1.5 py-0.5 font-mono text-[10px] text-white/0 transition-all group-hover:text-white/30 hover:bg-white/5! hover:text-white/60!"
     >
       {copied ? (
         <>
@@ -155,13 +155,13 @@ export default function ChatDrawer() {
             animate={{ x: 0 }}
             exit={{ x: '100%' }}
             transition={DRAWER_SPRING}
-            className="fixed top-0 right-0 z-50 flex h-full w-full flex-col border-l border-[#f0ede6]/8 bg-[#0b0d17]/95 backdrop-blur-xl md:w-[420px]"
+            className="fixed top-0 right-0 z-50 flex h-full w-full flex-col border-l bg-[#0b0d17]/95 backdrop-blur-xl md:w-[420px]"
           >
             {/* Header */}
-            <div className="flex items-center justify-between border-b border-[#f0ede6]/8 px-6 py-4">
+            <div className="flex items-center justify-between border-b px-6 py-4">
               <div className="flex items-center gap-3">
                 <div className="relative">
-                  <img src="/favicon.svg" alt="" className="h-5 w-5 rounded-sm" />
+                  <img src="/favicon.svg" alt="" className="h-5 w-5 rounded-xs" />
                   <div className="absolute -top-0.5 -right-0.5 h-2 w-2 animate-pulse rounded-full bg-accent" />
                 </div>
                 <div>
@@ -197,8 +197,8 @@ export default function ChatDrawer() {
               {messages.length === 0 ? (
                 /* ── Empty State ──────────────────────────────────────── */
                 <div className="flex h-full flex-col items-center justify-center">
-                  <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full border border-[#f0ede6]/8 bg-[#f0ede6]/5">
-                    <img src="/favicon.svg" alt="" className="h-8 w-8 rounded-sm" />
+                  <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full border bg-[#f0ede6]/5">
+                    <img src="/favicon.svg" alt="" className="h-8 w-8 rounded-xs" />
                   </div>
                   <p className="mb-8 max-w-[280px] text-center text-sm font-light text-[#f0ede6]/40">
                     Ask me anything about David&apos;s experience, projects, or technical
@@ -209,7 +209,7 @@ export default function ChatDrawer() {
                       <button
                         key={i}
                         onClick={() => sendMessage(q)}
-                        className="rounded-lg border border-[#f0ede6]/5 bg-[#f0ede6]/[0.02] px-4 py-3 text-left text-sm text-[#f0ede6]/45 transition-all hover:border-accent/15 hover:bg-accent/[0.04] hover:text-[#f0ede6]/70"
+                        className="rounded-lg border bg-[#f0ede6]/[0.02] px-4 py-3 text-left text-sm text-[#f0ede6]/45 transition-all hover:border-accent/15 hover:bg-accent/[0.04] hover:text-[#f0ede6]/70"
                       >
                         {q}
                       </button>
@@ -228,7 +228,7 @@ export default function ChatDrawer() {
                         className={`group relative max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed ${
                           message.role === 'user'
                             ? 'bg-[#f0ede6]/10 text-[#f0ede6]'
-                            : 'border border-[#f0ede6]/6 bg-[#f0ede6]/[0.03] text-[#f0ede6]/80'
+                            : 'border bg-[#f0ede6]/[0.03] text-[#f0ede6]/80'
                         }`}
                       >
                         {message.role === 'assistant' && !message.content && isStreaming ? (
@@ -273,7 +273,7 @@ export default function ChatDrawer() {
             </div>
 
             {/* Input */}
-            <div className="border-t border-[#f0ede6]/8 px-4 py-4">
+            <div className="border-t px-4 py-4">
               <div className="flex items-center gap-2 rounded-xl border border-[#f0ede6]/10 bg-[#f0ede6]/[0.03] px-4 py-2 transition-colors focus-within:border-accent/30">
                 <span className="font-mono text-xs text-accent/50">~</span>
                 <input
@@ -284,7 +284,7 @@ export default function ChatDrawer() {
                   onKeyDown={handleKeyDown}
                   placeholder="Ask about David..."
                   disabled={isStreaming}
-                  className="flex-1 bg-transparent text-sm text-white placeholder:text-white/20 focus:outline-none disabled:opacity-50"
+                  className="flex-1 bg-transparent text-sm text-white placeholder:text-white/20 focus:outline-hidden disabled:opacity-50"
                 />
                 <button
                   onClick={handleSend}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -91,8 +91,8 @@ export default function Navbar() {
       <nav
         className={`fixed z-50 flex items-center justify-center overflow-hidden transition-all duration-[800ms] ease-[cubic-bezier(0.16,1,0.3,1)] ${
           isScrolled
-            ? 'top-0 left-0 h-16 w-full translate-x-0 rounded-none border-b border-[#f0ede6]/8 bg-[#060810]/80 shadow-[0_10px_40px_rgba(0,0,0,0.5)] saturate-[1.5] backdrop-blur-2xl md:h-20'
-            : 'top-6 left-1/2 h-12 w-[240px] -translate-x-1/2 rounded-full border border-[#f0ede6]/8 bg-[#0b0d17]/80 backdrop-blur-xl md:top-8 md:h-14 md:w-[280px] md:hover:w-[calc(100vw-6rem)] lg:hover:w-[calc(100vw-12rem)] md:hover:max-w-[1400px]'
+            ? 'top-0 left-0 h-16 w-full translate-x-0 rounded-none border-b bg-[#060810]/80 shadow-[0_10px_40px_rgba(0,0,0,0.5)] saturate-[1.5] backdrop-blur-2xl md:h-20'
+            : 'top-6 left-1/2 h-12 w-[240px] -translate-x-1/2 rounded-full border bg-[#0b0d17]/80 backdrop-blur-xl md:top-8 md:h-14 md:w-[280px] md:hover:w-[calc(100vw-6rem)] lg:hover:w-[calc(100vw-12rem)] md:hover:max-w-[1400px]'
         } group cursor-pointer md:cursor-default`}
         onClick={() => {
           if (!isScrolled && window.innerWidth < 768) setIsMobileMenuOpen(true)
@@ -129,7 +129,7 @@ export default function Navbar() {
             Adarkwah.
           </span>
 
-          <div className="hidden items-center gap-1 rounded-full border border-[#f0ede6]/6 bg-[#0b0d17]/60 p-1.5 shadow-inner md:flex">
+          <div className="hidden items-center gap-1 rounded-full border bg-[#0b0d17]/60 p-1.5 inset-shadow-sm md:flex">
             {NAV_ITEMS.map((nav) => (
               <button
                 key={nav.id}

--- a/src/components/sections/Archive.tsx
+++ b/src/components/sections/Archive.tsx
@@ -83,7 +83,7 @@ export default function Archive() {
   return (
     <section
       id="projects"
-      className="relative z-20 border-t border-[#f0ede6]/6 bg-surface py-20 md:py-32"
+      className="relative z-20 border-t bg-surface py-20 md:py-32"
     >
       <div className="mx-auto max-w-[1400px] px-6 md:px-12 lg:px-24">
         {/* Header & Filters */}
@@ -97,7 +97,7 @@ export default function Archive() {
             </h3>
           </div>
 
-          <div className="hide-scroll flex w-full max-w-full gap-1 overflow-x-auto rounded-full border border-[#f0ede6]/8 bg-elevated p-1 font-mono text-xs tracking-widest uppercase md:w-auto md:gap-2">
+          <div className="hide-scroll flex w-full max-w-full gap-1 overflow-x-auto rounded-full border bg-elevated p-1 font-mono text-xs tracking-widest uppercase md:w-auto md:gap-2">
             {FILTERS.map((f) => (
               <button
                 key={f}
@@ -114,7 +114,7 @@ export default function Archive() {
 
         {/* Project List */}
         <div ref={listRef} className="flex w-full flex-col" style={{ minHeight: listMinHeight }}>
-          <div className="hidden grid-cols-12 gap-6 border-b border-[#f0ede6]/12 pb-6 font-mono text-xs tracking-widest text-warm/40 uppercase md:grid">
+          <div className="hidden grid-cols-12 gap-6 border-b pb-6 font-mono text-xs tracking-widest text-warm/40 uppercase md:grid">
             <div className="col-span-5 pl-4">Title / Designation</div>
             <div className="col-span-4">Category</div>
             <div className="col-span-2">Year</div>
@@ -125,7 +125,7 @@ export default function Archive() {
             const isExpanded = expandedId === item.id
 
             return (
-              <div key={item.id} className="group border-b border-[#f0ede6]/6">
+              <div key={item.id} className="group border-b">
                 <div
                   onClick={() => setExpandedId(isExpanded ? null : item.id)}
                   className="grid cursor-pointer grid-cols-1 items-center gap-3 px-3 py-5 transition-colors hover:bg-[#f0ede6]/[0.03] md:grid-cols-12 md:gap-6 md:px-4 md:py-6"
@@ -150,7 +150,7 @@ export default function Archive() {
                       className={`flex items-center gap-2 rounded-full border px-3 py-1 font-mono text-xs transition-colors md:text-sm ${
                         isExpanded
                           ? 'border-accent/25 bg-accent/10 text-accent'
-                          : 'border-[#f0ede6]/6 bg-transparent text-[#f0ede6]/45 group-hover:border-accent/20'
+                          : 'bg-transparent text-[#f0ede6]/45 group-hover:border-accent/20'
                       }`}
                     >
                       {item.type === 'System' && <Terminal className="h-3 w-3" />}
@@ -189,11 +189,11 @@ export default function Archive() {
                 >
                   <div className="overflow-hidden">
                     <div
-                      className={`mx-2 mb-2 mt-0 flex flex-col gap-6 rounded-2xl border border-[#f0ede6]/6 bg-elevated p-4 transition-all duration-1000 md:m-4 md:mt-0 md:gap-8 md:p-8 lg:flex-row ${
+                      className={`mx-2 mb-2 mt-0 flex flex-col gap-6 rounded-2xl border bg-elevated p-4 transition-all duration-1000 md:m-4 md:mt-0 md:gap-8 md:p-8 lg:flex-row ${
                         isExpanded ? 'translate-y-0 opacity-100' : '-translate-y-10 opacity-0'
                       }`}
                     >
-                      <div className="relative h-44 w-full overflow-hidden rounded-xl border border-[#f0ede6]/6 bg-[#060810] md:h-80 lg:w-5/12">
+                      <div className="relative h-44 w-full overflow-hidden rounded-xl border bg-[#060810] md:h-80 lg:w-5/12">
                         <img
                           src={item.image}
                           alt={item.title}
@@ -214,7 +214,7 @@ export default function Archive() {
                             isExpanded ? 'translate-x-0 opacity-100' : 'translate-x-8 opacity-0'
                           }`}
                         >
-                          <h5 className="mb-4 border-b border-[#f0ede6]/8 pb-2 font-mono text-sm tracking-widest text-warm/50 uppercase">
+                          <h5 className="mb-4 border-b pb-2 font-mono text-sm tracking-widest text-warm/50 uppercase">
                             Overview
                           </h5>
                           <p className="mb-6 text-sm leading-relaxed font-light text-[#f0ede6]/80 md:mb-8 md:text-xl">
@@ -230,7 +230,7 @@ export default function Archive() {
                           {item.stack.map((tech, i) => (
                             <span
                               key={i}
-                              className="rounded-sm border border-warm/15 bg-warm/8 px-3 py-1.5 font-mono text-[10px] tracking-widest text-warm/70 uppercase"
+                              className="rounded-xs border border-warm/15 bg-warm/8 px-3 py-1.5 font-mono text-[10px] tracking-widest text-warm/70 uppercase"
                             >
                               {tech}
                             </span>

--- a/src/components/sections/CareerEvolution.tsx
+++ b/src/components/sections/CareerEvolution.tsx
@@ -75,10 +75,10 @@ export default function CareerEvolution() {
   return (
     <section
       id="trajectory"
-      className="relative z-20 border-t border-[#f0ede6]/6 bg-void py-20 md:py-32"
+      className="relative z-20 border-t bg-void py-20 md:py-32"
     >
       <div className="mx-auto max-w-[1400px] px-6 md:px-12 lg:px-24">
-        <div className="mb-12 flex items-center justify-between border-b border-[#f0ede6]/8 pb-6 md:mb-24 md:pb-8">
+        <div className="mb-12 flex items-center justify-between border-b pb-6 md:mb-24 md:pb-8">
           <h2 className="flex items-center gap-3 font-mono text-sm tracking-[0.2em] text-[#f0ede6]/40 uppercase">
             <Layers className="h-4 w-4" /> Trajectory
           </h2>

--- a/src/components/sections/IdentityProtocol.tsx
+++ b/src/components/sections/IdentityProtocol.tsx
@@ -49,7 +49,7 @@ export default function IdentityProtocol() {
 
       {/* Part A — Axioms */}
       <div className="mx-auto max-w-[1400px] px-6 md:px-12 lg:px-24">
-        <div className="mb-12 flex items-center justify-between border-b border-[#f0ede6]/8 pb-6 md:mb-20 md:pb-8">
+        <div className="mb-12 flex items-center justify-between border-b pb-6 md:mb-20 md:pb-8">
           <h2 className="flex items-center gap-3 font-mono text-sm tracking-[0.2em] text-[#f0ede6]/40 uppercase">
             <Fingerprint className="h-4 w-4" /> About
           </h2>
@@ -70,7 +70,7 @@ export default function IdentityProtocol() {
             <div className="space-y-4 text-base leading-relaxed font-light text-[#f0ede6]/60 md:text-lg">
               <p>{personalInfo.philosophy}</p>
             </div>
-            <div className="grid grid-rows-2 gap-6 border-t border-[#f0ede6]/8 pt-6 md:gap-8 md:border-t-0 md:border-l md:pt-0 md:pl-12">
+            <div className="grid grid-rows-2 gap-6 border-t pt-6 md:gap-8 md:border-t-0 md:border-l md:pt-0 md:pl-12">
               <div>
                 <span className="mb-2 block font-serif text-2xl text-[#f0ede6] md:text-3xl">01</span>
                 <span className="mb-2 block font-mono text-xs tracking-widest text-warm/50 uppercase">
@@ -169,7 +169,7 @@ Current Focus
                         className={`rounded border px-3 py-1.5 font-mono text-[10px] tracking-widest uppercase transition-colors duration-700 ${
                           isActive
                             ? 'border-accent/30 bg-accent/10 text-accent'
-                            : 'border-[#f0ede6]/8 bg-[#f0ede6]/5 text-[#f0ede6]/30'
+                            : 'bg-[#f0ede6]/5 text-[#f0ede6]/30'
                         }`}
                       >
                         {award.category}

--- a/src/components/sections/Uplink.tsx
+++ b/src/components/sections/Uplink.tsx
@@ -56,7 +56,7 @@ export default function Uplink() {
         </div>
       </section>
 
-      <footer className="border-t border-[#f0ede6]/6 px-6 py-10 md:px-12 lg:px-24">
+      <footer className="border-t px-6 py-10 md:px-12 lg:px-24">
         <div className="mx-auto flex max-w-[1400px] flex-col items-center justify-between gap-6 md:flex-row">
           <div className="flex flex-col items-center gap-1 md:items-start">
             <span className="font-serif text-2xl font-medium tracking-tighter text-[#f0ede6]">
@@ -66,7 +66,7 @@ export default function Uplink() {
               Engineer. Architect. Builder.
             </span>
           </div>
-          <span className="text-center font-mono text-xs tracking-widest text-[#f0ede6]/18">
+          <span className="text-center font-mono text-xs tracking-widest text-[#f0ede6]/30">
             © {new Date().getFullYear()} David Adarkwah. All rights reserved.
           </span>
         </div>


### PR DESCRIPTION
## Summary
   - Remove Tailwind CDN script and inline config from layout.tsx
   - Add `@import "tailwindcss"` in globals.css with theme tokens and base resets
   - Set default border color to `rgba(240, 237, 230, 0.12)` for consistent dark UI borders
   - Update deprecated v3 class syntax across all components (hover:!, rounded-xs, outline-hidden, inset-shadow-sm)